### PR TITLE
Fix JSON marshal error on "204" responses when listing registries/repositories

### DIFF
--- a/pkg/v1/registry/requests.go
+++ b/pkg/v1/registry/requests.go
@@ -61,6 +61,11 @@ func List(ctx context.Context, client *v1.ServiceClient) ([]*Registry, *v1.Respo
 	// Extract registries from the response body.
 	registries := make([]*Registry, 0)
 
+	// If the status code is 204 No Content, return an empty list.
+	if responseResult.StatusCode == http.StatusNoContent {
+		return registries, responseResult, nil
+	}
+
 	err = responseResult.ExtractResult(&registries)
 	if err != nil {
 		return nil, responseResult, err

--- a/pkg/v1/registry/testing/requests_test.go
+++ b/pkg/v1/registry/testing/requests_test.go
@@ -176,6 +176,50 @@ func TestList(t *testing.T) {
 	}
 }
 
+func TestListEmpty(t *testing.T) {
+	endpointCalled := false
+	testEnv := testutils.SetupTestEnv()
+	defer testEnv.TearDownTestEnv()
+
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/api/v1/registries",
+		RawResponse: "",
+		Method:      http.MethodGet,
+		Status:      http.StatusNoContent,
+		CallFlag:    &endpointCalled,
+	})
+
+	ctx := context.Background()
+	testClient := &v1.ServiceClient{
+		HTTPClient: &http.Client{},
+		Token:      testutils.TokenID,
+		Endpoint:   testEnv.Server.URL + "/api/v1",
+		UserAgent:  testutils.UserAgent,
+	}
+
+	actual, httpResponse, err := registry.List(ctx, testClient)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !endpointCalled {
+		t.Fatal("endpoint wasn't called")
+	}
+	if httpResponse == nil {
+		t.Fatal("expected an HTTP response from the Get method")
+	}
+	if httpResponse.StatusCode != http.StatusNoContent {
+		t.Fatalf("expected %d status in the HTTP response, but got %d",
+			http.StatusOK, httpResponse.StatusCode)
+	}
+	if actual == nil {
+		t.Fatal("expected an empty list of registries, but got nil")
+	}
+	if len(actual) != 0 {
+		t.Fatalf("expected an empty list of registries, but got %d items", len(actual))
+	}
+}
+
 func TestDelete(t *testing.T) {
 	endpointCalled := false
 	testEnv := testutils.SetupTestEnv()

--- a/pkg/v1/repository/requests.go
+++ b/pkg/v1/repository/requests.go
@@ -34,6 +34,12 @@ func ListRepositories(ctx context.Context, client *v1.ServiceClient, registryID 
 
 	// Extract repositories from the response body.
 	repositories := make([]*Repository, 0)
+
+	// If the status code is 204 No Content, return an empty list.
+	if responseResult.StatusCode == http.StatusNoContent {
+		return repositories, responseResult, nil
+	}
+
 	err = responseResult.ExtractResult(&repositories)
 	if err != nil {
 		return nil, responseResult, err

--- a/pkg/v1/repository/testing/requests_test.go
+++ b/pkg/v1/repository/testing/requests_test.go
@@ -52,6 +52,50 @@ func TestListRepositories(t *testing.T) {
 	}
 }
 
+func TestListRepositoriesEmpty(t *testing.T) {
+	endpointCalled := false
+	testEnv := testutils.SetupTestEnv()
+	defer testEnv.TearDownTestEnv()
+
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/api/v1/registries/" + testRegistryID + "/repositories",
+		RawResponse: "",
+		Method:      http.MethodGet,
+		Status:      http.StatusNoContent,
+		CallFlag:    &endpointCalled,
+	})
+
+	ctx := context.Background()
+	testClient := &v1.ServiceClient{
+		HTTPClient: &http.Client{},
+		Token:      testutils.TokenID,
+		Endpoint:   testEnv.Server.URL + "/api/v1",
+		UserAgent:  testutils.UserAgent,
+	}
+
+	actual, httpResponse, err := repository.ListRepositories(ctx, testClient, testRegistryID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !endpointCalled {
+		t.Fatal("endpoint wasn't called")
+	}
+	if httpResponse == nil {
+		t.Fatal("expected an HTTP response from the Get method")
+	}
+	if httpResponse.StatusCode != http.StatusNoContent {
+		t.Fatalf("expected %d status in the HTTP response, but got %d",
+			http.StatusOK, httpResponse.StatusCode)
+	}
+	if actual == nil {
+		t.Fatal("expected an empty list of registries, but got nil")
+	}
+	if len(actual) != 0 {
+		t.Fatalf("expected an empty list of registries, but got %d items", len(actual))
+	}
+}
+
 func TestGetRepository(t *testing.T) {
 	endpointCalled := false
 	testEnv := testutils.SetupTestEnv()


### PR DESCRIPTION
This PR fixes an issue where a 204 No Content response when listing registries or repositories caused a JSON marshal error. Now, the code properly handles empty responses and skips marshaling when there is no content.